### PR TITLE
Pre-11.10 has no Chef::RequestID, introduced in chef commit a4cdce6.

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -4,6 +4,10 @@
 # Copyright 2014, HiganWorks LLC.
 #
 
+if not defined? Chef::RequestID
+  require 'securerandom'
+end
+
 class Chef::Handler::Elasticsearch < ::Chef::Handler
   require 'timeout'
   attr_reader :opts, :config
@@ -56,7 +60,11 @@ class Chef::Handler::Elasticsearch < ::Chef::Handler
 
     begin
       res = timeout(@config[:timeout]) {
-        client.put([index, type, Chef::RequestID.instance.request_id].join('/'), body.to_json)
+        if defined? Chef::RequestID.instance.request_id
+          client.put([index, type, Chef::RequestID.instance.request_id].join('/'), body.to_json)
+        else
+          client.put([index, type, SecureRandom.uuid].join('/'), body.to_json)
+        end
       }
       Chef::Log.debug "===== Response from es following..."
       Chef::Log.debug res.to_s

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email 'sawanoboriyu@higanworks.com'
 license          'apache2'
 description      'Add elasticsearch report handler to chef-client'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.0.0'
+version          '1.0.1'


### PR DESCRIPTION
Using a random uuid in lieu of an actual Request ID if not defined? Chef::RequestID.

And, yes, I know the real solution to this is probably to upgrade...
