### PR TITLE
Add support for deleting keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ chef_handler_elasticsearch CHANGELOG
 
 This file is used to list changes made in each version of the chef_handler_elasticsearch cookbook.
 
+1.0.2
+-----
+- Add "delete_keys" support
+
 1.0.1
 -----
 - Use SecureRandom for Pre-11.10

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Attributes
 - node[:chef_handler_elasticsearch][:index_use_utc]
   - Use utc to index name.
   - default: `true`
+- node[:chef_handler_elasticsearch][:delete_keys]
+  - Delete some keys from report data before sending to Elasticsearch. Useful for deleting all_resources, updated_resources, node details, etc.
+  - default: [] (Don't delete)
 
 
 ### elasticsearch template settings.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -13,3 +13,4 @@ default[:chef_handler_elasticsearch][:mappings] = '{
     "dynamic_date_formats" : ["yyyy-MM-dd HH:mm:ss Z", "date_optional_time"]
   }
 }'
+default[:chef_handler_elasticsearch][:delete_keys] = []

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -22,6 +22,7 @@ class Chef::Handler::Elasticsearch < ::Chef::Handler
       template_order: 10,
       index_use_utc: true,
       index_date_format: "%Y.%m.%d",
+      delete_keys: [],
       mappings: default_mapping
     }
     @opts = opts
@@ -54,6 +55,10 @@ class Chef::Handler::Elasticsearch < ::Chef::Handler
     prepare_template(client) if @config[:prepare_template]
 
     body = data.merge({'@timestamp' => Time.at(data[:end_time]).to_datetime.to_s})
+
+    @config[:delete_keys].each do |key|
+      body.tap { |h| h.delete(key.to_sym) }
+    end
 
     Chef::Log.debug "===== Puts to es following..."
     Chef::Log.debug body.to_s

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email 'sawanoboriyu@higanworks.com'
 license          'apache2'
 description      'Add elasticsearch report handler to chef-client'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.0.1'
+version          '1.0.2'


### PR DESCRIPTION
This PR adds support for a "delete_keys" parameter, which will delete data from the hash before sending it to ElasticSearch.

In my case, I only want summarized run data -- I don't care about the individual resources updated, and I don't want to store all of that data in ES.

I use it like this:

```
Chef::Config[:exception_handlers] << Chef::Handler::Elasticsearch.new(
  url: "http://my.es.cluster:9200/",
  prefix: "chef",
  timeout: 10,
  delete_keys: ["all_resources", "node", "updated_resources"],
)
```
